### PR TITLE
Remove branch DEVSEC-403 from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - DEVSEC-403
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This branch was used for testing the CI builds.